### PR TITLE
Update route.py (remove deprecated `ModelFilter`)

### DIFF
--- a/backends/inference/route.py
+++ b/backends/inference/route.py
@@ -12,7 +12,6 @@ from huggingface_hub import (
     hf_hub_download,
     get_hf_file_metadata,
     hf_hub_url,
-    ModelFilter,
     HfApi,
 )
 
@@ -182,9 +181,7 @@ def search_models(payload):
     models = hf_api.list_models(
         sort=sort,  # or "downloads" or "trending"
         limit=limit,
-        filter=ModelFilter(
-            task=task,
-        ),
+        task=task,
     )
     return {
         "success": True,


### PR DESCRIPTION
This PR remove deprecated use of `ModelFilter`. Arguments can now be passed to `list_models` directly. See https://github.com/huggingface/huggingface_hub/issues/2028 for more details.