### PR TITLE
Use model config passed from frontend

### DIFF
--- a/backends/core/common.py
+++ b/backends/core/common.py
@@ -1132,8 +1132,8 @@ def get_model_install_config(model_id: str = None) -> dict:
     """Get model installation config from text_model_configs.json.
 
     Returns the full models list when no model_id is given. When a model_id is
-    given but not present in the registry, returns an empty config dict — callers
-    are expected to supply the needed fields (messageFormat, modelName) directly.
+    given but not present in the registry, returns {} — callers are expected to
+    supply the needed fields (messageFormat, modelName) directly.
     """
     try:
         config_path = dep_path(os.path.join("public", "text_model_configs.json"))
@@ -1143,7 +1143,7 @@ def get_model_install_config(model_id: str = None) -> dict:
                 return dict(models=text_models)
             config = text_models.get(model_id)
             if config is None:
-                return dict(models=text_models)
+                return {}
             message_format = config["messageFormat"]
             model_name = config["name"]
             tags = config.get("tags")

--- a/backends/core/common.py
+++ b/backends/core/common.py
@@ -1129,14 +1129,21 @@ def release_server_port(port: int):
 
 
 def get_model_install_config(model_id: str = None) -> dict:
-    """Get model installation config from text_model_configs.json"""
+    """Get model installation config from text_model_configs.json.
+
+    Returns the full models list when no model_id is given. When a model_id is
+    given but not present in the registry, returns an empty config dict — callers
+    are expected to supply the needed fields (messageFormat, modelName) directly.
+    """
     try:
         config_path = dep_path(os.path.join("public", "text_model_configs.json"))
         with open(config_path, "r") as file:
             text_models = json.load(file)
             if not model_id:
                 return dict(models=text_models)
-            config = text_models[model_id]
+            config = text_models.get(model_id)
+            if config is None:
+                return dict(models=text_models)
             message_format = config["messageFormat"]
             model_name = config["name"]
             tags = config.get("tags")

--- a/backends/inference/classes.py
+++ b/backends/inference/classes.py
@@ -141,6 +141,8 @@ class LoadTextInferenceInit(BaseModel):
 class LoadInferenceRequest(BaseModel):
     modelId: str
     modelPath: Optional[str] = None  # If not provided, looked up from modelId
+    messageFormat: Optional[str] = None  # Prompt format key (e.g. "qwen"). If not provided, looked up from modelId
+    modelName: Optional[str] = None  # Display name. If not provided, looked up from modelId
     raw_input: Optional[bool] = False  # user can send manually formatted messages
     responseMode: Optional[str] = DEFAULT_CHAT_MODE
     toolUseMode: Optional[str] = DEFAULT_TOOL_USE_MODE
@@ -326,6 +328,7 @@ class LoadVisionInferenceRequest(BaseModel):
     modelId: str
     modelPath: Optional[str] = None  # If not provided, looked up from modelId
     mmprojPath: Optional[str] = None  # If not provided, looked up from modelId
+    modelName: Optional[str] = None  # Display name. If not provided, looked up from modelId
     init: LoadTextInferenceInit
     call: LoadTextInferenceCall
 

--- a/backends/inference/route.py
+++ b/backends/inference/route.py
@@ -160,11 +160,19 @@ async def load_text_inference(
         if app.state.llm:
             print(f"{common.PRNT_API} Ejecting current model before loading {model_id}")
             await unload_text_inference(request)
-        # Load the config for the model
-        model_config = get_model_install_config(model_id)
-        message_format_id = model_config.get("message_format")
-        model_name = model_config.get("model_name")
-        tags = model_config.get("tags") or []
+        # Resolve message_format and model_name. Caller-provided values win;
+        # otherwise fall back to the server-side registry for models the caller
+        # didn't pre-configure.
+        message_format_id = data.messageFormat
+        model_name = data.modelName
+        if not message_format_id or not model_name:
+            model_config = get_model_install_config(model_id)
+            message_format_id = message_format_id or model_config.get("message_format")
+            model_name = model_name or model_config.get("model_name")
+        if not message_format_id:
+            raise Exception(
+                f"messageFormat not provided and {model_id} not found in registry."
+            )
         # Enable --reasoning-format deepseek at launch time when the caller
         # opts into thinking mode. Reasoning is bound to the loaded model —
         # to toggle it, the model must be reloaded with a different call.enable_thinking.

--- a/backends/inference/route.py
+++ b/backends/inference/route.py
@@ -170,8 +170,9 @@ async def load_text_inference(
             message_format_id = message_format_id or model_config.get("message_format")
             model_name = model_name or model_config.get("model_name")
         if not message_format_id:
-            raise Exception(
-                f"messageFormat not provided and {model_id} not found in registry."
+            raise HTTPException(
+                status_code=422,
+                detail=f"messageFormat not provided and {model_id} not found in registry.",
             )
         # Enable --reasoning-format deepseek at launch time when the caller
         # opts into thinking mode. Reasoning is bound to the loaded model —

--- a/backends/vision/route.py
+++ b/backends/vision/route.py
@@ -82,9 +82,12 @@ async def load_vision_model(
             await app.state.llm.unload()
             app.state.llm = None
 
-        # Get model config
-        model_config = get_model_install_config(model_id)
-        model_name = model_config.get("model_name")
+        # Resolve model_name. Caller-provided value wins; otherwise fall back
+        # to the server-side registry.
+        model_name = data.modelName
+        if not model_name:
+            model_config = get_model_install_config(model_id)
+            model_name = model_config.get("model_name")
 
         # Create unified model instance with mmproj for vision capability
         app.state.llm = LlamaServer(

--- a/backends/vision/route.py
+++ b/backends/vision/route.py
@@ -88,6 +88,8 @@ async def load_vision_model(
         if not model_name:
             model_config = get_model_install_config(model_id)
             model_name = model_config.get("model_name")
+        if not model_name:
+            print(f"{common.PRNT_API} Warning: modelName not provided and {model_id} not found in registry. Proceeding without a display name.")
 
         # Create unified model instance with mmproj for vision capability
         app.state.llm = LlamaServer(

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "obrew-studio-server",
-  "version": "0.15.1",
+  "version": "0.15.2",
   "author": "OpenBrewAi",
   "license": "MIT",
   "productName": "Obrew Studio Engine",


### PR DESCRIPTION
This de-couples the backend's curated list of models and the frontend's that want to load/download anything.

FileBuff can now load any model by passing modelId, modelPath, messageFormat, and modelName directly — no need to pre-register it in text_model_configs.json. The registry is now only required for models that should appear in the /models browser list, or for clients that don't want to pass their own metadata.

Related issue: https://github.com/dieharders/obrew-studio-server/issues/157